### PR TITLE
Chore: Freshen up - switch to gospawn and remove references to expired gpg keys

### DIFF
--- a/Dockerfile-nrpe-full
+++ b/Dockerfile-nrpe-full
@@ -1,16 +1,7 @@
 FROM debian:testing-slim
 MAINTAINER martin scharm <https://binfalse.de>
 
-# nrpe server cannot log to std::out, so we need syslog2stdout (i provide a package at apt.binfalse.de)
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends gnupg dirmngr \
-    && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E81BC3078D2DD9BD \
-    && gpg -a --export E81BC3078D2DD9BD | apt-key add - \
-    && echo "deb http://apt.binfalse.de binfalse main" > "/etc/apt/sources.list.d/binfalse.list" \
-    && echo "deb http://deb.debian.org/debian stable main" > "/etc/apt/sources.list.d/stable.list" \
-    && apt-get purge -y -q --autoremove gnupg dirmngr \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+RUN echo "deb http://deb.debian.org/debian stable main" > "/etc/apt/sources.list.d/stable.list"
 
 # install all the dependencied
 RUN apt-get update \
@@ -27,14 +18,16 @@ RUN apt-get update \
         liblwp-protocol-https-perl \
         libwww-perl \
         libhttp-cookies-perl \
-        bf-monitoring \
-        bf-syslog2stdout \
+        curl \
     && egrep -v "^((allowed_hosts|server_port|pid_file|include|include_dir)=|#)" /etc/nagios/nrpe.cfg | grep -v '^$' > /tmp/nrpe.cfg \
     && mv /tmp/nrpe.cfg /etc/nagios/nrpe.cfg \
     && echo "include=/etc/nagios/auto-manage.cfg" >> /etc/nagios/nrpe.cfg \
     && echo "include_dir=/etc/nagios/nrpe.d/" >> /etc/nagios/nrpe.cfg \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# nrpe server cannot log to std::out, so use gospawn.  See: https://github.com/ossobv/gospawn
+RUN curl -so /bin/gospawn https://junk.devs.nu/go/gospawn.upx && chmod +x /bin/gospawn
 
 VOLUME [ "/etc/nagios/nrpe.d/", "/etc/nagios/certs/", "/usr/lib/nagios/extra/" ]
 EXPOSE 5666

--- a/Dockerfile-nrpe-plain
+++ b/Dockerfile-nrpe-plain
@@ -1,27 +1,20 @@
 FROM debian:testing-slim
 MAINTAINER martin scharm <https://binfalse.de>
 
-# nrpe server cannot log to std::out, so we need syslog2stdout (i provide a package at apt.binfalse.de)
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends gnupg dirmngr \
-    && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E81BC3078D2DD9BD \
-    && gpg -a --export E81BC3078D2DD9BD | apt-key add - \
-    && echo "deb http://apt.binfalse.de binfalse main" > "/etc/apt/sources.list.d/binfalse.list" \
-    && apt-get purge -y -q --autoremove gnupg dirmngr \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
 # install all the dependencied
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         nagios-nrpe-server \
-        bf-syslog2stdout \
+        curl
     && egrep -v "^((allowed_hosts|server_port|pid_file|include|include_dir)=|#)" /etc/nagios/nrpe.cfg | grep -v '^$' > /tmp/nrpe.cfg \
     && mv /tmp/nrpe.cfg /etc/nagios/nrpe.cfg \
     && echo "include=/etc/nagios/auto-manage.cfg" >> /etc/nagios/nrpe.cfg \
     && echo "include_dir=/etc/nagios/nrpe.d/" >> /etc/nagios/nrpe.cfg \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# nrpe server cannot log to std::out, so use gospawn.  See: https://github.com/ossobv/gospawn
+RUN curl -so /bin/gospawn https://junk.devs.nu/go/gospawn.upx && chmod +x /bin/gospawn
 
 VOLUME [ "/etc/nagios/nrpe.d/", "/etc/nagios/certs/", "/usr/lib/nagios/extra/" ]
 EXPOSE 5666

--- a/src/nrpe-runner
+++ b/src/nrpe-runner
@@ -57,9 +57,6 @@ mkdir -p /var/run/nagios /etc/nagios/certs /usr/lib/nagios/extra
 [ -e "/var/run/nagios/nrpe.pid" ] && rm "/var/run/nagios/nrpe.pid"
 echo "pid_file=/var/run/nagios/nrpe.pid" >> $OURCONF
 
-# run the fake syslog to print the log to std::out
-/bin/syslog2stdout /dev/log &
-
-# run the server
-/usr/sbin/nrpe -c /etc/nagios/nrpe.cfg -f $SSLFLAG
+# run the fake syslog to print the log to std::out, and then run the server
+/bin/gospawn /dev/log -- /usr/sbin/nrpe -c /etc/nagios/nrpe.cfg -f $SSLFLAG
 


### PR DESCRIPTION
This started as an attempt to deal with the expired gpg keys linked to the apt repo, but the end result is:

* Remove references to expired gpg keys + private apt repos.  It is unclear if they are still maintained.
* Switch syslog2stdout to gospawn, which appears to be its better-maintained successor.

Closes #2.